### PR TITLE
feat(seki-schemas/v1/cloud): Add owner and visibility to cloud compon…

### DIFF
--- a/bigquery/componentrc.json
+++ b/bigquery/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Big Query",
   "kind": "bigquery",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Analitycs",
     "Warehouse",

--- a/centrifugo/componentrc.json
+++ b/centrifugo/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Centrifugo",
   "kind": "centrifugo",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "real-time",
     "messaging",

--- a/cloudflare_zone/componentrc.json
+++ b/cloudflare_zone/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Cloudflare Zone",
   "kind": "cloudflare_zone",
+  "owner": ["seki", "seki-ci"],
+  "visibility": "private",
   "tags": [
     "Security",
     "Cloudflare",

--- a/dataflow/componentrc.json
+++ b/dataflow/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "DataFlow",
   "kind": "dataflow",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Analitycs",
     "Warehouse",

--- a/dataproc/componentrc.json
+++ b/dataproc/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Dataproc",
   "kind": "dataproc",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Spark",
     "Hadoop",

--- a/dockerfile/componentrc.json
+++ b/dockerfile/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Dockerfile",
   "kind": "dockerfile",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Docker",
     "K8s",

--- a/elastic/componentrc.json
+++ b/elastic/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Elastic",
   "kind": "elastic",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Search",
     "Database",

--- a/google_bucket/componentrc.json
+++ b/google_bucket/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Google Bucket",
   "kind": "google_bucket",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Bucket",
     "GCP"

--- a/google_postgres/componentrc.json
+++ b/google_postgres/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Servidor de PostgreSQL",
   "kind": "google_postgres",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": ["SQL", "Database", "beta"],
   "icons": {
     "light": "icons/icon-white.svg",

--- a/kafka/componentrc.json
+++ b/kafka/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Kafka",
   "kind": "kafka",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Queue",
     "Confluent"

--- a/mongodb/componentrc.json
+++ b/mongodb/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Proyecto de MongoDB",
   "kind": "mongodb",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": ["NoSQL", "Database", "beta"],
   "icons": {
     "light": "icons/icon-white.svg",

--- a/npm/componentrc.json
+++ b/npm/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "NPM",
   "kind": "npm",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Package"
   ],

--- a/pubsub/componentrc.json
+++ b/pubsub/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "PubSub",
   "kind": "pubsub",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Queue",
     "GCP"

--- a/redis/componentrc.json
+++ b/redis/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Redis",
   "kind": "redis",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Database",
     "Memory",

--- a/sendgrid/componentrc.json
+++ b/sendgrid/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Send Grid",
   "kind": "sendgrid",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Messaging",
     "Email"

--- a/vertex_ai/componentrc.json
+++ b/vertex_ai/componentrc.json
@@ -2,6 +2,8 @@
   "$schema": "https://raw.githubusercontent.com/Cencosud-X/seki-schemas/main/v1/cloud/componentrc.schema.json",
   "name": "Vertex AI",
   "kind": "vertex_ai",
+  "owner": ["seki"],
+  "visibility": "internal",
   "tags": [
     "Analitycs",
     "Warehouse",


### PR DESCRIPTION
Se está usando un modelo más genérico, copia de github. En la meta data se define la visibilidad con respecto al owner. Privado, sólo para el owner; internal, para tos los productos y público, para todos. Los owner son productos y pueden ser más de uno para el caso de equipos multi-producto o colaboración. 
